### PR TITLE
Minor fixes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ The template does not include any Azure / other Cloud integration. Refer to [SAF
 
 ## Using the template
 
-* Install the template: `dotnet new -i SAFE.Template::*`
-* Create new project from the template: `dotnet new SAFE`
+* Install or update the template: `dotnet new -i SAFE.Template`
+* Create a new project from the template: `dotnet new SAFE`
 * Build the project: `build.cmd` / `build.sh`
 * Run (working dir root of project): `dotnet run --project src\Server\Server.fsproj`
 * Preview in browser: `http://localhost:8080/index.html`


### PR DESCRIPTION
Mainly because with dotnet SDK 2 you don`t need `::*` when installing a template.

I guess we also need a README within the template itself and also explain how to do hot reloading with Fable.