### PR TITLE
fixed template with Giraffe Server

### DIFF
--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -1,10 +1,10 @@
 ﻿open System
 open System.IO
 open System.Threading.Tasks
-
 open Microsoft.AspNetCore
 open Microsoft.AspNetCore.Builder
 open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.DependencyInjection
 
 open Giraffe
 
@@ -38,11 +38,15 @@ let configureApp  (app : IApplicationBuilder) =
   app.UseStaticFiles()
      .UseGiraffe webApp
 
+let configureServices (services : IServiceCollection) =
+    services.AddGiraffe() |> ignore
+
 WebHost
   .CreateDefaultBuilder()
   .UseWebRoot(clientPath)
   .UseContentRoot(clientPath)
   .Configure(Action<IApplicationBuilder> configureApp)
+  .ConfigureServices(configureServices)
   .UseUrls("http://0.0.0.0:" + port.ToString() + "/")
   .Build()
   .Run()


### PR DESCRIPTION
Fixed [Issue42](https://github.com/SAFE-Stack/SAFE-template/issues/42) when Giraffe Server fails with NRE,  cause hasnt `ConfigureServices` section in Server.fs