### PR TITLE
Update Remoting, use latest API

### DIFF
--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -16,11 +16,11 @@ group Server
   nuget Fable.JsonConverter
 //#endif  
 //#if     (Remoting && Server == "suave")
-  nuget Fable.Remoting.Suave ~> 2.0
+  nuget Fable.Remoting.Suave ~> 2.6
 //#elseif (Remoting && Server == "giraffe")
-  nuget Fable.Remoting.Giraffe ~> 2.0
+  nuget Fable.Remoting.Giraffe ~> 2.6
 //#elseif (Remoting && Server == "saturn")
-  nuget Fable.Remoting.Giraffe ~> 2.0
+  nuget Fable.Remoting.Giraffe ~> 2.6
 //#endif
 
   clitool Microsoft.DotNet.Watcher.Tools
@@ -34,7 +34,7 @@ group Client
   nuget Fable.Elmish.React
   nuget Fable.Elmish.HMR
 //#if (Remoting)
-  nuget Fable.Remoting.Client ~> 2.0
+  nuget Fable.Remoting.Client ~> 2.4
 //#endif
 //#if (Fulma != "none")
   nuget Fulma 1.0.0-beta-007

--- a/Content/src/Client/Client.fs
+++ b/Content/src/Client/Client.fs
@@ -40,7 +40,9 @@ module Server =
   
   /// A proxy you can use to talk to server directly
   let api : ICounterProtocol = 
-    Proxy.createWithBuilder<ICounterProtocol> Route.builder
+    Proxy.remoting<ICounterProtocol> {
+      use_route_builder Route.builder
+    }
     
 #endif
 

--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -10,6 +10,7 @@ open Microsoft.Extensions.DependencyInjection
 open Giraffe
 
 #if (Remoting)
+open Fable.Remoting.Server
 open Fable.Remoting.Giraffe
 #else
 open Giraffe.Serialization
@@ -28,7 +29,9 @@ let webApp : HttpHandler =
   let counterProcotol = 
     { getInitCounter = getInitCounter >> Async.AwaitTask }
   // creates a HttpHandler for the given implementation
-  FableGiraffeAdapter.httpHandlerWithBuilderFor counterProcotol Route.builder
+  remoting counterProcotol {
+    use_route_builder Route.builder
+  }
 #else
   route "/api/init" >=>
     fun next ctx ->

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -29,7 +29,7 @@ let server =
 
 let webApp =
   remoting server {
-    with_builder Route.builder
+    use_route_builder Route.builder
   }
 
 let mainRouter = scope {

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -5,6 +5,7 @@ open Suave
 open Suave.Operators
 
 #if (Remoting)
+open Fable.Remoting.Server
 open Fable.Remoting.Suave
 #endif
 
@@ -24,8 +25,11 @@ let init : WebPart =
 #if (Remoting)
   let counterProcotol = 
     { getInitCounter = getInitCounter }
-  // creates a WebPart for the given implementation
-  FableSuaveAdapter.webPartWithBuilderFor counterProcotol Route.builder
+  // Create a WebPart for the given implementation of the protocol
+  remoting counterProcotol {
+    // define how routes are mapped
+    use_route_builder Route.builder 
+  }
 #else
   Filters.path "/api/init" >=>
   fun ctx ->


### PR DESCRIPTION
Update server adapters to 2.6 / client to 2.4, these are most stable and most heavily tested versions. 

Use latest `remoting` API to create the handlers in accordance with the [docs](https://zaid-ajaj.github.io/Fable.Remoting/), (still backwards compatible)   

I only tested the template with Suave server locally.

Suggestion: 
 - Use default remoting implementation without `Route.builder`?
 - rename `Route.builder` to `Route.prefixWithApi`? 