### PR TITLE
Add support for Azure storage

### DIFF
--- a/Content/arm-template.json
+++ b/Content/arm-template.json
@@ -10,6 +10,7 @@
         "prefix": "[concat('safe-', parameters('environment'))]",
         "appServicePlan": "[concat(variables('prefix'), '-web-host')]",
         "web": "[concat(variables('prefix'), '-web')]",
+        "storage": "[concat('safe', parameters('environment'), 'storage')]",
         "insights": "[concat(variables('prefix'), '-insights')]"
     },
     "resources": [
@@ -28,6 +29,20 @@
                 "name": "[variables('insights')]"
             }
         },
+
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "sku": {
+                "name": "Standard_LRS",
+                "tier": "Standard"
+            },
+            "kind": "Storage",
+            "name": "[variables('storage')]",
+            "apiVersion": "2017-10-01",
+            "location": "[parameters('location')]",
+            "tags": {}
+        },
+        
         {
             "type": "Microsoft.Web/serverfarms",
             "sku": { "name": "[parameters('pricingTier')]" },
@@ -56,12 +71,14 @@
                     "type": "config",
                     "properties": {
                         "public_path": "./public",
+                        "STORAGE_CONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storage'), ';AccountKey=', listKeys(resourceId('Microsoft.Storage/storageAccounts/', variables('storage')), '2017-10-01').keys[0].value)]",
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(concat('Microsoft.Insights/components/', variables('insights'))).InstrumentationKey]"
                     },
                     "tags": { "displayName": "WebAppSettings" },
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites/', variables('web'))]",
                         "[resourceId('Microsoft.Insights/components/', variables('insights'))]",
+                        "[concat('Microsoft.Storage/storageAccounts/', variables('storage'))]",
                         "Microsoft.ApplicationInsights.AzureWebSites"
                     ]                
                 },

--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -21,6 +21,7 @@ group Server
 //#endif
 //#if (Deploy == "azure")
   nuget Microsoft.ApplicationInsights.AspNetCore ~> 2.2
+  nuget WindowsAzure.Storage
 //#endif
 
   clitool Microsoft.DotNet.Watcher.Tools

--- a/Content/src/Server/paket.references
+++ b/Content/src/Server/paket.references
@@ -11,6 +11,7 @@ group Server
 //#endif
 //#if (Deploy == "azure")
   Microsoft.ApplicationInsights.AspNetCore
+  WindowsAzure.Storage
 //#endif
 //#if     (!Remoting && Server != "suave")
   Fable.JsonConverter


### PR DESCRIPTION
This is probably as far as we should go in terms of a "generic" Azure SAFE implementation. It adds a Storage account to the ARM template, links it to the application through a connection string, adds the basic Azure Storage SDK to the Server project and creates an instance of the CloudStorageAccount.

Note: The local development environment (currently) only exists on Windows (and even that requires an installation). Nonetheless, this is still a good starting point for working with Azure Storage (provided we document it!).