### PR TITLE
Solidified Bundle target

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -139,7 +139,7 @@ Target.create "Docker" (fun _ ->
 //#endif
 //#if (deploy == "azure")
 Target.create "Bundle" (fun _ ->
-    runDotNet (sprintf "publish %s -c release -o %s" serverPath deployDir) __SOURCE_DIRECTORY__
+    runDotNet (sprintf "publish \"%s\" -c release -o \"%s\"" serverPath deployDir) __SOURCE_DIRECTORY__
     Shell.copyDir (Path.combine deployDir "public") (Path.combine clientPath "public") FileFilter.allFiles
 )
 


### PR DESCRIPTION
I created the app in the dir: _C:\Users\peter\Desktop\dev life\SAFE_.
Bundle target produces an unclear exception and MSBuild error: "_Only one project can be specified_".

Escaping strings fixes this.