### PR TITLE
Pin compatible Remoting.Server version, fixes #116

### DIFF
--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -15,8 +15,10 @@ group Server
 //#if (!remoting && server != "suave")
     nuget Fable.JsonConverter
 //#elseif (remoting && server == "suave")
+    nuget Fable.Remoting.Server ~> 3.6
     nuget Fable.Remoting.Suave ~> 2.7
 //#elseif (remoting && server != "suave")
+    nuget Fable.Remoting.Server ~> 3.6
     nuget Fable.Remoting.Giraffe ~> 2.7
 //#endif
 //#if (deploy == "azure")


### PR DESCRIPTION
This fixes #116, Fable.Remoting had an [upgrade](https://zaid-ajaj.github.io/Fable.Remoting/src/change-log.html) and it seems that dependencies with the breaking changes are being resolved instead of the compatible dependencies

I will be able to upgrade the template to latest remoting version very soon, for now, this should work.