### PR TITLE
Update remoting to latest, docs for client

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -42,7 +42,7 @@ let npmTool = platformTool "npm" "npm.cmd"
 let yarnTool = platformTool "yarn" "yarn.cmd"
 //#endif
 
-let install = lazy DotNet.install DotNet.Release_2_1_300
+let install = lazy DotNet.install DotNet.Versions.Release_2_1_300
 
 let inline withWorkDir wd =
     DotNet.Options.lift install.Value
@@ -221,7 +221,8 @@ open Fake.Core.TargetOperators
     ==> "AppService"
 //#endif
 
-"InstallClient"
+"Clean"
+    ==> "InstallClient"
     ==> "RestoreServer"
     ==> "Run"
 

--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -15,11 +15,9 @@ group Server
 //#if (!remoting && server != "suave")
     nuget Fable.JsonConverter
 //#elseif (remoting && server == "suave")
-    nuget Fable.Remoting.Server ~> 3.6
-    nuget Fable.Remoting.Suave ~> 2.7
+    nuget Fable.Remoting.Suave 
 //#elseif (remoting && server != "suave")
-    nuget Fable.Remoting.Server ~> 3.6
-    nuget Fable.Remoting.Giraffe ~> 2.7
+    nuget Fable.Remoting.Giraffe 
 //#endif
 //#if (deploy == "azure")
     nuget Microsoft.ApplicationInsights.AspNetCore ~> 2.2
@@ -35,7 +33,7 @@ group Client
     nuget Fable.Elmish.React
     nuget Fable.Elmish.HMR
 //#if (remoting)
-    nuget Fable.Remoting.Client ~> 2.5.1
+    nuget Fable.Remoting.Client
 //#endif
 //#if (layout != "none")
     nuget Fulma

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -26,15 +26,18 @@ let publicPath = Path.GetFullPath "../Client/public"
 //#endif
 let port = 8085us
 
-let getInitCounter () : Task<Counter> = task { return 42 }
+let getInitCounter() : Task<Counter> = task { return 42 }
 
 #if (remoting)
+let counterApi = {
+    initialCounter = getInitCounter >> Async.AwaitTask 
+}
+
 let webApp =
-    let server =
-        { getInitCounter = getInitCounter >> Async.AwaitTask }
-    remoting server {
-        use_route_builder Route.builder
-    }
+    Remoting.createApi()
+    |> Remoting.withRouteBuilder Route.builder 
+    |> Remoting.fromValue counterApi 
+    |> Remoting.buildHttpHandler
 
 #else
 let webApp = scope {
@@ -62,7 +65,7 @@ let configureAzure (services:IServiceCollection) =
 #endif
 let app = application {
     url ("http://0.0.0.0:" + port.ToString() + "/")
-    router webApp
+    use_router webApp
     memory_cache
     use_static publicPath
     #if (!remoting)
@@ -70,11 +73,6 @@ let app = application {
     #endif
     #if (deploy == "azure")
     service_config configureAzure
-    #endif
-    #if (remoting)
-    // sitemap diagnostic data cannot be inferred when using Fable.Remoting
-    // Saturn issue at https://github.com/SaturnFramework/Saturn/issues/64
-    disable_diagnostics
     #endif
     use_gzip
 }

--- a/Content/src/Shared/Shared.fs
+++ b/Content/src/Shared/Shared.fs
@@ -8,9 +8,8 @@ module Route =
     let builder typeName methodName =
         sprintf "/api/%s/%s" typeName methodName
 
-/// A type that specifies the communication protocol for client and server
-/// Every record field must have the type : 'a -> Async<'b> where 'a can also be `unit`
-/// Add more such fields, implement them on the server and they be directly available on client
-type ICounterProtocol =
-    { getInitCounter : unit -> Async<Counter> }
+/// A type that specifies the communication protocol between client and server
+/// to learn more, read the docs at https://zaid-ajaj.github.io/Fable.Remoting/src/basics.html
+type ICounterApi =
+    { initialCounter : unit -> Async<Counter> }
 #endif


### PR DESCRIPTION
This PR updates remoting to latest version and api, I also took the liberty and updated a couple of things along the way, PLEASE REVIEW (I haven't tested every possible combination): 

## Client
Added docs to model, msg, init and update 

`type Model = Counter option` became `type Model = { Counter: Counter option }`  

The messages now became:
```fs
type Msg =
| Increment
| Decrement
| LoadInitialCount 
| InitialCountLoaded of Result<Counter, exn>
```
where `LoadInitialCount` is a message the initiates the request and `InitialCountLoaded` is the one that results from the (http) request, and `init()` becomes:
```fs
// defines the initial state and initial command (= side-effect) of the application
let init () : Model * Cmd<Msg> =
    let initialModel = { Counter = None }
    let initialCmd = Cmd.ofMsg LoadInitialCount
    initialModel, initialCmd
```
## Saturn
`use_router` instead of `router` as per the depreciation message 
`disable_diagnostics` doesn't seem necessary anymore with remoting enabled (probably because the [routing with remoting](https://github.com/Zaid-Ajaj/Fable.Remoting/blob/master/Fable.Remoting.Giraffe/FableGiraffeAdapter.fs#L73) doesn't rely on existing combinators any more) 
## Suave
opening `Suave.Filters` and `Suave.Successful` instead of fully qualifying them with the `OK` and `path` web parts (it is common that they are fully qualified?) 

## build.fsx
`DotNet.Release_2_1_300` => `DotNet.Versions.Release_2_1_300` as per the depreciation message 
`Run` target is `Clean`-ed before running