### PR TITLE
Add Heroku support

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -109,6 +109,10 @@
                 {
                     "choice": "docker",
                     "description": "additional FAKE targets to bundle and build Docker image"
+                },
+                {
+                    "choice": "heroku",
+                    "description": "additional FAKE targets to deploy on Heroku"
                 }
             ]
         }
@@ -203,6 +207,10 @@
                 {
                     "exclude": "arm-template.json",
                     "condition": "(deploy != \"azure\")"
+                },
+                {
+                    "exclude": "app.json",
+                    "condition": "(deploy != \"heroku\")"
                 },
                 {
                     "exclude": "yarn.lock",

--- a/Content/app.json
+++ b/Content/app.json
@@ -1,0 +1,9 @@
+{
+    "buildpacks": [
+    {
+      "url" : "heroku/nodejs"
+    },
+    {
+      "url" : "https://github.com/SAFE-Stack/SAFE-buildpack"
+    }]
+  }

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -42,16 +42,13 @@ let npmTool = platformTool "npm" "npm.cmd"
 let yarnTool = platformTool "yarn" "yarn.cmd"
 //#endif
 
-//#if (deploy == "heroku")
-// Heroku may fail if trying to install a different version. Use the default
-let install = lazy DotNet.install id
-//#else
+//#if (deploy != "heroku")
 let install = lazy DotNet.install DotNet.Versions.Release_2_1_300
-//#endif
+
 let inline withWorkDir wd =
     DotNet.Options.lift install.Value
     >> DotNet.Options.withWorkingDirectory wd
-
+//#endif
 let runTool cmd args workingDir =
     let result =
         Process.execSimple (fun info ->
@@ -64,7 +61,12 @@ let runTool cmd args workingDir =
 
 let runDotNet cmd workingDir =
     let result =
+//#if (deploy == "heroku")
+        // Heroku may fail if trying to install a different version. Use the default
+        DotNet.exec id cmd ""
+//#else
         DotNet.exec (withWorkDir workingDir) cmd ""
+//#endif
     if result.ExitCode <> 0 then failwithf "'dotnet %s' failed in %s" cmd workingDir
 
 let openBrowser url =

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -134,7 +134,7 @@ Target.create "Bundle" (fun _ ->
 
     Shell.copyDir publicDir "src/Client/public" FileFilter.allFiles
 //#if (deploy == "heroku")
-    let procFile = sprintf "web: cd \"%s\" && dotnet Server.dll" serverDir
+    let procFile = sprintf "web: cd \"%s\" && dotnet Server.dll" (Path.shortenCurrentDirectory serverDir)
     File.writeNew "Procfile" [procFile]
 //#endif
 

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -42,7 +42,7 @@ let npmTool = platformTool "npm" "npm.cmd"
 let yarnTool = platformTool "yarn" "yarn.cmd"
 //#endif
 
-//#if (deploy != "heroku")
+//#if (deploy == "heroku")
 let inline withWorkDir wd =
 //#else
 let install = lazy DotNet.install DotNet.Versions.Release_2_1_300

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -43,12 +43,15 @@ let yarnTool = platformTool "yarn" "yarn.cmd"
 //#endif
 
 //#if (deploy != "heroku")
+let inline withWorkDir wd =
+//#else
 let install = lazy DotNet.install DotNet.Versions.Release_2_1_300
 
 let inline withWorkDir wd =
-    DotNet.Options.lift install.Value
-    >> DotNet.Options.withWorkingDirectory wd
+    DotNet.Options.lift install.Value >>
 //#endif
+    DotNet.Options.withWorkingDirectory wd
+
 let runTool cmd args workingDir =
     let result =
         Process.execSimple (fun info ->
@@ -61,12 +64,7 @@ let runTool cmd args workingDir =
 
 let runDotNet cmd workingDir =
     let result =
-//#if (deploy == "heroku")
-        // Heroku may fail if trying to install a different version. Use the default
-        DotNet.exec id cmd ""
-//#else
         DotNet.exec (withWorkDir workingDir) cmd ""
-//#endif
     if result.ExitCode <> 0 then failwithf "'dotnet %s' failed in %s" cmd workingDir
 
 let openBrowser url =

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -42,8 +42,12 @@ let npmTool = platformTool "npm" "npm.cmd"
 let yarnTool = platformTool "yarn" "yarn.cmd"
 //#endif
 
+//#if (deploy == "heroku")
+// Heroku may fail if trying to install a different version. Use the default
+let install = lazy DotNet.install id
+//#else
 let install = lazy DotNet.install DotNet.Versions.Release_2_1_300
-
+//#endif
 let inline withWorkDir wd =
     DotNet.Options.lift install.Value
     >> DotNet.Options.withWorkingDirectory wd

--- a/Content/src/Client/webpack.config.js
+++ b/Content/src/Client/webpack.config.js
@@ -20,7 +20,7 @@ var babelOptions = fableUtils.resolveBabelOptions({
 
 
 var isProduction = process.argv.indexOf("-p") >= 0;
-var port = process.env.SUAVE_FABLE_PORT || "8085";
+var port = process.env.SUAVE_FABLE_PORT || process.env.PORT || "8085";
 console.log("Bundling for " + (isProduction ? "production" : "development") + "...");
 
 module.exports = {

--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -24,10 +24,15 @@ open Microsoft.WindowsAzure.Storage
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
 let publicPath = tryGetEnv "public_path" |> Option.defaultValue "../Client/public" |> Path.GetFullPath
 let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
+let port = 8085us
+//#elseif (deploy == "heroku")
+let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+let publicPath = Path.GetFullPath "../Client/public"
+let port = tryGetEnv "PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
-//#endif
 let port = 8085us
+//#endif
 
 let getInitCounter () : Task<Counter> = task { return 42 }
 #if (remoting)

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -21,10 +21,15 @@ open Microsoft.WindowsAzure.Storage
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
 let publicPath = tryGetEnv "public_path" |> Option.defaultValue "../Client/public" |> Path.GetFullPath
 let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
+let port = 8085us
+//#elseif (deploy == "heroku")
+let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+let publicPath = Path.GetFullPath "../Client/public"
+let port = tryGetEnv "PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
-//#endif
 let port = 8085us
+//#endif
 
 let getInitCounter() : Task<Counter> = task { return 42 }
 

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -24,6 +24,7 @@ let storageAccount = Azure.tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaul
 //#elseif (deploy == "heroku")
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
 let port = tryGetEnv "PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
+let publicPath = Path.GetFullPath "../Client/public"
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 let port = 8085us

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -21,6 +21,9 @@ open Microsoft.WindowsAzure.Storage
 let publicPath = Azure.tryGetEnv "public_path" |> Option.defaultValue "../Client/public" |> Path.GetFullPath
 let port = Azure.tryGetEnv "HTTP_PLATFORM_PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 let storageAccount = Azure.tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
+//#elseif (deploy == "heroku")
+let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+let port = tryGetEnv "PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 let port = 8085us

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -63,6 +63,7 @@ let serverGen = Gen.elements [
 let deployGen = Gen.elements [
     None
     Some "docker"
+    Some "heroku"
     // https://travis-ci.org/SAFE-Stack/SAFE-template/builds/409831921?utm_source=github_status&utm_medium=notification
     // Some "azure"
 ]


### PR DESCRIPTION
Implements #136 

I'm using `https://github.com/SAFE-Stack/SAFE-buildpack` as a placeholder. I created a [branch](https://github.com/Nhowka/dotnetcore-buildpack/tree/SAFE) on my modified buildpack for supporting it. You can change it to `https://github.com/Nhowka/dotnetcore-buildpack#SAFE` if you don't want to have it under the org name.

I also had to change the `--port free` position because it wasn't being recognized. Weird.