### PR TITLE
Add GCP appengine support

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -141,6 +141,10 @@
                 {
                     "choice": "docker",
                     "description": "additional FAKE targets to bundle and build Docker image"
+                },
+                {
+                    "choice": "gcp-appengine",
+                    "description": "additional FAKE targets to deploy to GCP appengine"
                 }
             ]
         }
@@ -457,7 +461,11 @@
                 },
                 {
                     "exclude": "Dockerfile",
-                    "condition": "(deploy != \"docker\")"
+                    "condition": "(deploy != \"docker\" && deploy != \"gcp-appengine\" )"
+                },
+                {
+                    "exclude": "app.yaml",
+                    "condition": "(deploy != \"gcp-appengine\" )"
                 },
                 {
                     "exclude": "arm-template.json",

--- a/Content/app.yaml
+++ b/Content/app.yaml
@@ -19,4 +19,4 @@ resources:
     disk_size_gb: 10
 
 env_variables:
-    SERVER_PROXY_PORT: "8080"
+    SERVER_PORT: "8080"

--- a/Content/app.yaml
+++ b/Content/app.yaml
@@ -1,0 +1,22 @@
+runtime: custom
+env: flex
+
+# Depends on the app
+# For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/nodejs/reference/app-yaml#health_checks
+health_check:
+    enable_health_check: False
+
+# This sample incurs costs to run on the App Engine flexible environment.
+# The settings below are to reduce costs during testing and are not appropriate
+# for production use. For more information, see:
+# https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml
+manual_scaling:
+    instances: 1
+resources:
+    cpu: 1
+    memory_gb: 0.5
+    disk_size_gb: 10
+
+env_variables:
+    SERVER_PROXY_PORT: "8080"

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -123,7 +123,7 @@ Target.create "Run" (fun _ ->
     |> ignore
 )
 
-//#if (deploy == "docker")
+//#if (deploy == "docker" || deploy == "gcp-appengine")
 Target.create "Bundle" (fun _ ->
     let serverDir = Path.combine deployDir "Server"
     let clientDir = Path.combine deployDir "Client"
@@ -221,18 +221,30 @@ Target.create "AppService" (fun _ ->
     client.UploadData(destinationUri, IO.File.ReadAllBytes zipFile) |> ignore)
 //#endif
 
+//#if (deploy == "gcp-appengine")
+Target.create "Deploy" (fun _ ->
+    let args = sprintf "app deploy --quiet"
+    runTool "gcloud" args "."
+)
+//#endif
+
 open Fake.Core.TargetOperators
 
 "Clean"
     ==> "InstallClient"
     ==> "Build"
-//#if (deploy == "docker")
+//#if (deploy == "docker" || deploy == "gcp-appengine")
     ==> "Bundle"
     ==> "Docker"
 //#elseif (deploy == "azure")
     ==> "Bundle"
     ==> "ArmTemplate"
     ==> "AppService"
+//#endif
+
+//#if (deploy == "gcp-appengine")
+"Bundle"
+    ==> "Deploy"
 //#endif
 
 "Clean"

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -223,8 +223,7 @@ Target.create "AppService" (fun _ ->
 
 //#if (deploy == "gcp-appengine")
 Target.create "Deploy" (fun _ ->
-    let args = sprintf "app deploy --quiet"
-    runTool "gcloud" args "."
+    runTool "gcloud" "app deploy --quiet" "."
 )
 //#endif
 

--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -19,14 +19,15 @@ open Fable.Remoting.Giraffe
 open Microsoft.WindowsAzure.Storage
 #endif
 
-//#if (deploy == "azure")
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+
+//#if (deploy == "azure")
 let publicPath = tryGetEnv "public_path" |> Option.defaultValue "../Client/public" |> Path.GetFullPath
 let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
-let port = 8085us
+let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter () : Task<Counter> = task { return { Value = 42 } }
 #if (remoting)

--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -27,7 +27,7 @@ let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
-let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter () : Task<Counter> = task { return { Value = 42 } }
 #if (remoting)

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -16,14 +16,16 @@ open Fable.Remoting.Giraffe
 open Microsoft.WindowsAzure.Storage
 #endif
 
-//#if (deploy == "azure")
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+
+//#if (deploy == "azure")
 let publicPath = tryGetEnv "public_path" |> Option.defaultValue "../Client/public" |> Path.GetFullPath
 let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
-let port = 8085us
+
+let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter() : Task<Counter> = task { return { Value = 42 } }
 

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -25,7 +25,7 @@ let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
 
-let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter() : Task<Counter> = task { return { Value = 42 } }
 

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -30,7 +30,7 @@ let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" 
 
 let publicPath = Path.GetFullPath "../Client/public"
 
-let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 //#endif
 
 let config =

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -26,8 +26,11 @@ let publicPath = Azure.tryGetEnv "public_path" |> Option.defaultValue "../Client
 let port = Azure.tryGetEnv "HTTP_PLATFORM_PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 let storageAccount = Azure.tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
 //#else
+let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
+
 let publicPath = Path.GetFullPath "../Client/public"
-let port = 8085us
+
+let port = "SERVER_PROXY_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 //#endif
 
 let config =

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A dotnet CLI template for [SAFE-Stack](https://safe-stack.github.io/) projects.
 This is a basic template to get started with each of the core components of the stack:
 
 * [Saturn](https://saturnframework.github.io/docs/), [Giraffe](https://github.com/giraffe-fsharp/Giraffe) or [Suave](https://suave.io/)
-* [Azure App Service](https://azure.microsoft.com/) and [Docker](https://www.docker.com/) integration.
+* [Azure App Service](https://azure.microsoft.com/), [Google Cloud AppEngine](https://cloud.google.com/appengine/) and [Docker](https://www.docker.com/) integration.
 * [Fable](http://fable.io/)
 * [Elmish](https://elmish.github.io/elmish/)
 


### PR DESCRIPTION
Add support for google cloud appengine.

- [x] Add `gcp-appengine` deploy option
- [x] Add support to specify port with environment variables for suave, giraffe and saturn
- [x] Add basic `app.yaml` that is used for deploy to GCP appengine
- [x] Modify `template.json` to include `Dockerfile` and `app.yaml` for `gcp-appengine` deploy type
- [x] Add link to Google Cloud Appengine in readme
- [x] Add deploy target to build script

To really test you need a gcp project and gcloud installed. For now the same Dockerfile as for docker deploy is used, it might make sense to change to a dedicated one for gcp later for easier integration with other gcp services. 

To do a test deploy run the following two commands:

```
dotnet new SAFE --deploy gcp-appengine
fake build --target deploy
```

Deploy of appengine flex apps is not super fast, but as long as there are no errors it should work.