### PR TITLE
Remove FAKE issue warning

### DIFF
--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -54,7 +54,7 @@ group Build
     framework: netstandard2.0
     storage: none
 
-    nuget FSharp.Core 4.3.4 // https://github.com/fsharp/FAKE/issues/2001
+    nuget FSharp.Core
     nuget Fake.Core.Target
     nuget Fake.DotNet.Cli
     nuget Fake.IO.FileSystem


### PR DESCRIPTION
If I understand @matthid correctly, then this is no longer needed