### PR TITLE
[WIP] Support heroku

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -151,6 +151,10 @@
                 {
                     "choice": "iis",
                     "description": "FAKE targets and client paths normalization to easily publish the application to IIS"
+                },
+                {
+                    "choice": "heroku",
+                    "description": "additional FAKE targets to deploy on Heroku"
                 }
             ]
         }

--- a/Content/src/Server/ServerGiraffe.fs
+++ b/Content/src/Server/ServerGiraffe.fs
@@ -27,7 +27,13 @@ let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue
 //#else
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
-let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port =
+//#if (deploy == "heroku")
+    "PORT"
+//#else
+    "SERVER_PORT"
+//#endif
+    |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter () : Task<Counter> = task { return { Value = 42 } }
 #if (remoting)

--- a/Content/src/Server/ServerSaturn.fs
+++ b/Content/src/Server/ServerSaturn.fs
@@ -25,7 +25,13 @@ let storageAccount = tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue
 let publicPath = Path.GetFullPath "../Client/public"
 //#endif
 
-let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port =
+//#if (deploy == "heroku")
+    "PORT"
+//#else
+    "SERVER_PORT"
+//#endif
+    |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 
 let getInitCounter() : Task<Counter> = task { return { Value = 42 } }
 

--- a/Content/src/Server/ServerSuave.fs
+++ b/Content/src/Server/ServerSuave.fs
@@ -31,14 +31,14 @@ let publicPath = Azure.tryGetEnv "public_path" |> Option.defaultValue "../Client
 let port = Azure.tryGetEnv "HTTP_PLATFORM_PORT" |> Option.map System.UInt16.Parse |> Option.defaultValue 8085us
 let storageAccount = Azure.tryGetEnv "STORAGE_CONNECTIONSTRING" |> Option.defaultValue "UseDevelopmentStorage=true" |> CloudStorageAccount.Parse
 //#elseif (deploy == "iis")
-module ServerPath = 
-    let workingDirectory = 
+module ServerPath =
+    let workingDirectory =
         let currentAsm = Assembly.GetExecutingAssembly()
         let codeBaseLoc = currentAsm.CodeBase
         let localPath = Uri(codeBaseLoc).LocalPath
         Directory.GetParent(localPath).FullName
 
-    let resolve segments = 
+    let resolve segments =
         let paths = Array.concat [| [| workingDirectory |]; Array.ofList segments |]
         Path.GetFullPath(Path.Combine(paths))
 
@@ -48,7 +48,13 @@ let port = tryGetEnv "HTTP_PLATFORM_PORT" |> Option.map System.UInt16.Parse |> O
 //#else
 let tryGetEnv = System.Environment.GetEnvironmentVariable >> function null | "" -> None | x -> Some x
 let publicPath = Path.GetFullPath "../Client/public"
-let port = "SERVER_PORT" |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
+let port =
+//#if (deploy == "heroku")
+    "PORT"
+//#else
+    "SERVER_PORT"
+//#endif
+    |> tryGetEnv |> Option.map uint16 |> Option.defaultValue 8085us
 //#endif
 
 let config =

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -79,6 +79,7 @@ let deployGen =
         Some "gcp-appengine"
         Some "gcp-kubernetes"
         Some "iis"
+        Some "heroku"
     ]
 
 let layoutGen =


### PR DESCRIPTION
There is a link to `https://github.com/SAFE-Stack/SAFE-buildpack`. The working buildpack for testing is `https://github.com/Nhowka/dotnetcore-buildpack#SAFETEST` instead.

After the login on `heroku-cli`, using `fake build -t configure` and `fake build -t deploy` should be enough to start a template made with `dotnet new SAFE --deploy heroku`.

As the FAKE script will run on the heroku machine too, I repeat the `herokuTool` and `gitTool` inside the targets so it won't raise an exception for not finding them.

It should be used instead of #137 as it is very outdated.