### PR TITLE
Add devocntainer definition

### DIFF
--- a/Content/.devcontainer/Dockerfile
+++ b/Content/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2
+
+# Add keys and sources lists
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" \
+    | tee /etc/apt/sources.list.d/yarn.list
+
+# Install node, 7zip, yarn, mono, git, process tools
+RUN apt-get update && apt-get install -y nodejs p7zip-full yarn git procps
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install fake
+RUN dotnet tool install fake-cli -g
+
+# Install fake
+RUN dotnet tool install paket -g
+
+# add dotnet tools to path to pick up fake and paket installation
+ENV PATH="/root/.dotnet/tools:${PATH}"
+
+# Copy endpoint specific user settings into container to specify
+# .NET Core should be used as the runtime.
+COPY settings.vscode.json /root/.vscode-remote/data/Machine/settings.json

--- a/Content/.devcontainer/devcontainer.json
+++ b/Content/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+	"name": "SAFE",
+	"dockerFile": "Dockerfile",
+	"appPort": [8080, 8085],
+	"extensions": [
+		"ionide.ionide-fsharp",
+        "ms-vscode.csharp",
+        "editorconfig.editorconfig",
+        "msjsdiag.debugger-for-chrome"
+	]
+}

--- a/Content/.devcontainer/settings.vscode.json
+++ b/Content/.devcontainer/settings.vscode.json
@@ -1,0 +1,3 @@
+{
+    "FSharp.fsacRuntime":"netcore"
+}


### PR DESCRIPTION
Having in the devcontainer definition in workspace will make VSCode (if user have `remote-containers` extension installed) prompt user to open the workspace inside the defined docker container.
As you can see in the docker container we have .Net SDK 2.2, Node, Yarn, Paket and FAKE - i.e all our requirements.
VSCode will also automatically install the extensions specified in `devcontainer.json`.

All this means users can start developing applications with VSCode and docker as only requirements - and they will automatically get full configure development environment with all dependencies installed.