### PR TITLE
Set Fable variable on client project

### DIFF
--- a/Content/src/Client/Client.fsproj
+++ b/Content/src/Client/Client.fsproj
@@ -2,6 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <DefineConstants>FABLE_COMPILER</DefineConstants>
     </PropertyGroup>
     <ItemGroup>
         <Compile Include="..\Shared\Shared.fs" />


### PR DESCRIPTION
this makes the ionide aware of the fact that this is a fable project.
This is needed if `#if FABLE_COMPILER` directives that are sometimes needed for SSR - especially when you want to have Thoth.Fetch in one end and Thoth.Net on the other.

/cc @Krzysztof-Cieslak @isaacabraham @MangelMaxime 