### PR TITLE
no need to restore client

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -130,7 +130,6 @@ Target.create "InstallClient" (fun _ ->
     runTool yarnTool "--version" __SOURCE_DIRECTORY__
     runTool yarnTool "install --frozen-lockfile" __SOURCE_DIRECTORY__
 //#endif
-    runDotNet "restore" clientPath
 )
 
 Target.create "Build" (fun _ ->


### PR DESCRIPTION
I don't think this is still needed.
I think I added it long time ago in bookstorish project because fable was a dotnet tool that we needed to restore explicitly.