### PR TITLE
Have the Docker build process set up its environment

### DIFF
--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -162,6 +162,10 @@
                     "description": "additional FAKE targets to bundle and build Docker image"
                 },
                 {
+                    "choice": "docker-build",
+                    "description": "additional FAKE targets to build a Docker image with docker build"
+                },
+                {
                     "choice": "gcp-appengine",
                     "description": "additional FAKE targets to deploy to Google Cloud AppEngine"
                 },
@@ -611,7 +615,7 @@
                 },
                 {
                     "exclude": "Dockerfile",
-                    "condition": "(deploy != \"docker\" && deploy != \"gcp-appengine\" && deploy != \"gcp-kubernetes\" )"
+                    "condition": "(deploy != \"docker\" && deploy != \"gcp-appengine\" && deploy != \"gcp-kubernetes\" && deploy != \"docker-build\" )"
                 },
                 {
                     "exclude": "app.yaml",

--- a/Content/Dockerfile
+++ b/Content/Dockerfile
@@ -1,5 +1,71 @@
+//#if (deploy == "docker-build")
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
+
+RUN TERM=noninteractive apt-get update
+
+# From SAFE-Stack documentation - pull the prereqs
+# FAKE
+RUN dotnet tool install -g fake-cli
+# Node.JS
+RUN curl -sL https://deb.nodesource.com/setup_10.x -o nodesource_setup.sh
+RUN bash ./nodesource_setup.sh
+RUN TERM=noninteractive apt-get -y install build-essential nodejs
+# Yarn
+RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN TERM=noninteractive apt-get update && apt-get -y install yarn
+# paket
+RUN dotnet tool install -g Paket
+
+# Now build the app. For some reason, despite using -g, the tools got installed
+# locally only but that's OK, we'll just add them to the PATH
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.dotnet/tools
+
+# Copy over everything that is important. We don't just ADD . because this
+# will destroy the cache. We add the files and dirs in an order that makes
+# it possible to use as much of the cache as possible.
+RUN mkdir /build
+ADD .devcontainer /build/.devcontainer
+ADD .paket /build/.paket
+ADD .vscode /build/.vscode
+ADD .editorconfig /build/
+ADD RELEASE_NOTES.md /build/
+ADD README.md /build/
+ADD *.sln /build/
+ADD build.fsx /build/
+ADD webpack.config.js /build/
+ADD package.json /build/
+ADD paket.* /build/
+ADD yarn.lock /build/
+ADD src /build/src/
+
+# Enter the build dir
+WORKDIR /build
+
+# Just to be sure: Run yarn install and paket install to know additional pkgs
+# that might have been added
+RUN yarn install
+RUN paket install
+
+# Now build
+RUN fake build -t Bundle
+
+# Switch to a smaller .net Core image for running
+FROM mcr.microsoft.com/dotnet/core/runtime:2.2
+
+COPY --from=build /build/deploy/ /app/
+
+# Get into the Server dir, that's where the app is run from
+WORKDIR /app/Server
+
+# Runtime options
+EXPOSE 8085
+ENTRYPOINT [ "dotnet", "Server.dll" ]
+//#else
 FROM microsoft/dotnet:2.2-aspnetcore-runtime-alpine
 COPY /deploy /
 WORKDIR /Server
 EXPOSE 8085
 ENTRYPOINT [ "dotnet", "Server.dll" ]
+//#endif

--- a/Content/README.md
+++ b/Content/README.md
@@ -25,6 +25,11 @@ fake build -t Run
 You can use the included `Dockerfile` and `build.fsx` script to deploy your application as Docker container. You can find more regarding this topic in the [official template documentation](https://safe-stack.github.io/docs/template-docker/).
 
 //#endif
+//#if (deploy == "docker-build")
+
+You can use the included `Dockerfile` in conjunction with `docker build` to deploy your application as Docker container.
+
+//#endif
 //#if (deploy == "azure")
 
 You can use the included `arm-template.json` file and `build.fsx` script to deploy you application as an Azure Web App. Consult the [official template documentation](https://safe-stack.github.io/docs/template-appservice/) to learn more.

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -184,7 +184,9 @@ Target.create "Run" (fun _ ->
 let buildDocker tag =
     let args = sprintf "build -t %s ." tag
     runTool "docker" args "."
+//#endif
 
+//#if (deploy == "docker" || deploy == "gcp-kubernetes" || deploy == "gcp-appengine" || deploy == "docker-build")
 Target.create "Bundle" (fun _ ->
     let serverDir = Path.combine deployDir "Server"
     let clientDir = Path.combine deployDir "Client"
@@ -195,7 +197,9 @@ Target.create "Bundle" (fun _ ->
 
     Shell.copyDir publicDir clientDeployPath FileFilter.allFiles
 )
+//#endif
 
+//#if (deploy == "docker" || deploy == "gcp-kubernetes" || deploy == "gcp-appengine")
 let dockerUser = "safe-template"
 let dockerImageName = "safe-template"
 //#endif
@@ -391,8 +395,10 @@ open Fake.Core.TargetOperators
 "Clean"
     ==> "InstallClient"
     ==> "Build"
-//#if (deploy == "docker" || deploy == "gcp-appengine")
+//#if (deploy == "docker" || deploy == "gcp-appengine" || deploy == "docker-build")
     ==> "Bundle"
+//#endif
+//#if (deploy == "docker" || deploy == "gcp-appengine")
     ==> "Docker"
 //#elseif (deploy == "azure")
     ==> "Bundle"


### PR DESCRIPTION
This PR adds a `--deploy docker-build` option which sets up the `Dockerfile` and `build.fsx` in a way the Docker container can just be built by going into the root directory and typing `docker build -t mytag .`

This solves #289 