### PR TITLE
Add .ionide to gitignore

### DIFF
--- a/Content/.gitignore
+++ b/Content/.gitignore
@@ -13,3 +13,4 @@ release.sh
 *.orig
 *.DotSettings.user
 deploy
+.ionide/


### PR DESCRIPTION
Ionide builds up a symbol cache which it stores locally, we don't need this in source control. Given that we encourage people to use Ionide in VS we should ensure people don't encounter any unnecessary friction.