### PR TITLE
Use FAKE and Paket local tools in template output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ cache:
   directories:
   - $HOME/.yarn-cache
 
-env:
-  - FAKE_PATH=~/fake-cli/fake MAX_TESTS=10
-
 script:
-  - dotnet tool install fake-cli --tool-path ~/fake-cli
-  - $FAKE_PATH build -t tests
+  - dotnet tool restore
+  - dotnet fake build -t tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ cache:
   directories:
   - $HOME/.yarn-cache
 
+env:
+  - FAKE_PATH=~/fake-cli/fake MAX_TESTS=10
+
 script:
-  - dotnet tool restore
-  - dotnet fake build -t tests
+  - dotnet tool install fake-cli --tool-path ~/fake-cli
+  - $FAKE_PATH build -t tests

--- a/Content/.config/dotnet-tools.json
+++ b/Content/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "fake-cli": {
+      "version": "5.19.1",
+      "commands": [
+        "fake"
+      ]
+    },
+    "paket": {
+      "version": "5.242.2",
+      "commands": [
+        "paket"
+      ]
+    }
+  }
+}

--- a/Content/.devcontainer/Dockerfile
+++ b/Content/.devcontainer/Dockerfile
@@ -14,15 +14,6 @@ RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
-# Install fake
-RUN dotnet tool install fake-cli -g
-
-# Install Paket
-RUN dotnet tool install paket -g
-
-# add dotnet tools to path to pick up fake and paket installation
-ENV PATH="/root/.dotnet/tools:${PATH}"
-
 # Copy endpoint specific user settings into container to specify
 # .NET Core should be used as the runtime.
 COPY settings.vscode.json /root/.vscode-remote/data/Machine/settings.json

--- a/Content/.vscode/tasks.json
+++ b/Content/.vscode/tasks.json
@@ -14,8 +14,8 @@
         },
         {
             "label": "Watch Client and Server",
-            "command": "fake",
-            "args": [ "build", "-t", "Run" ],
+            "command": "dotnet",
+            "args": [ "fake", "build", "-t", "Run" ],
             "type": "shell",
             "options": {
                 "cwd": "${workspaceFolder}",
@@ -46,8 +46,8 @@
         },
         {
             "label": "Watch Client",
-            "command": "fake",
-            "args": [ "build", "-t", "Run" ],
+            "command": "dotnet",
+            "args": [ "fake", "build", "-t", "Run" ],
             "type": "shell",
             "options": {
                 "cwd": "${workspaceFolder}",

--- a/Content/README.md
+++ b/Content/README.md
@@ -7,17 +7,23 @@ This template can be used to generate a full-stack web application using the [SA
 You'll need to install the following pre-requisites in order to build SAFE applications
 
 * The [.NET Core SDK](https://www.microsoft.com/net/download)
-* [FAKE 5](https://fake.build/) installed as a [global tool](https://fake.build/fake-gettingstarted.html#Install-FAKE)
 * The [Yarn](https://yarnpkg.com/lang/en/docs/install/) package manager (you can also use `npm` but the usage of `yarn` is encouraged).
 * [Node LTS](https://nodejs.org/en/download/) installed for the front end components.
 * If you're running on OSX or Linux, you'll also need to install [Mono](https://www.mono-project.com/docs/getting-started/install/).
 
 ## Work with the application
 
+Before you run the project **for the first time only** you should install its local tools with this command:
+
+```bash
+dotnet tool restore
+```
+
+
 To concurrently run the server and the client components in watch mode use the following command:
 
 ```bash
-fake build -t Run
+dotnet fake build -t run
 ```
 
 //#if (deploy == "docker")
@@ -55,7 +61,3 @@ You will find more documentation about the used F# components at the following p
 //#endif
 
 If you want to know more about the full Azure Stack and all of it's components (including Azure) visit the official [SAFE documentation](https://safe-stack.github.io/docs/).
-
-## Troubleshooting
-
-* **fake not found** - If you fail to execute `fake` from command line after installing it as a global tool, you might need to add it to your `PATH` manually: (e.g. `export PATH="$HOME/.dotnet/tools:$PATH"` on unix) - [related GitHub issue](https://github.com/dotnet/cli/issues/9321)

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -20,11 +20,6 @@ let dotnet =
     | null -> "dotnet"
     | x -> x
 
-let fake =
-    match Environment.GetEnvironmentVariable "FAKE_PATH" with
-    | null -> "fake"
-    | x -> x
-
 let maxTests =
     match Environment.GetEnvironmentVariable "MAX_TESTS" with
     | null -> 15
@@ -270,14 +265,15 @@ let tests =
             Expect.isTrue (File.exists (dir </> "paket.lock"))
                 (sprintf "paket.lock not present for '%s'" newSAFEArgs)
 
-            // see if `fake build` succeeds
-            run fake "build" dir
+            run dotnet "tool restore" dir
+            // see if `dotnet fake build` succeeds
+            run dotnet ("fake build") dir
 
-            // see if `fake build -t run` succeeds and webpack serves the index page
+            // see if `dotnet fake build -t run` succeeds and webpack serves the index page
             let stdOutPhrase = ": Compiled successfully."
             let htmlSearchPhrase = """<title>SAFE Template</title>"""
             let timeout = TimeSpan.FromMinutes 5.
-            let proc = start fake "build -t run" dir
+            let proc = start dotnet "fake build -t run" dir
             try
                 let waitResult = waitForStdOut proc stdOutPhrase timeout
                 if waitResult then
@@ -285,7 +281,7 @@ let tests =
                     Expect.stringContains response htmlSearchPhrase
                         (sprintf "html fragment not found for '%s'" newSAFEArgs)
                 else
-                    raise (Expecto.FailedException (sprintf "`fake build -t run` timeout for '%s'" newSAFEArgs))
+                    raise (Expecto.FailedException (sprintf "`dotnet fake build -t run` timeout for '%s'" newSAFEArgs))
             finally
                 killProcessTree proc.Id
 


### PR DESCRIPTION
This removes FAKE and Paket as a global dependencies, using dotnet local tools instead.

- Tests don't work for me locally before or after my changes, possibly due to environmental issues.
- I've not tested the Dockerfile. I don't really use docker.

I haven't moved away from global tools for the SAFE-template project itself, but we should do that as the next step, unless @theimowski is doing this for v2 anyway.