### PR TITLE
Update publisher for vscode csharp extension

### DIFF
--- a/Content/.vscode/extensions.json
+++ b/Content/.vscode/extensions.json
@@ -5,7 +5,7 @@
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "ionide.ionide-fsharp",
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "editorconfig.editorconfig",
         "msjsdiag.debugger-for-chrome",
         "ms-vscode-remote.remote-containers"


### PR DESCRIPTION
The extension for csharp has changed publisher from ms-vscode to ms-dotnettools 

https://github.com/OmniSharp/omnisharp-vscode/pull/3610