### PR TITLE
Fix devServerProxy context paths

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -40,13 +40,13 @@ Target.create "BuildWebPackConfig" (fun _ ->
 
     let devServerProxy =
         """{
-        // redirect requests that start with /api/* to the server on port 8085
-        '/api/*': {
+        // redirect requests that start with /api/ to the server on port 8085
+        '/api/**': {
             target: 'http://localhost:' + (process.env.SERVER_PROXY_PORT || "8085"),
                changeOrigin: true
            },
-        // redirect websocket requests that start with /socket/* to the server on the port 8085
-        '/socket/*': {
+        // redirect websocket requests that start with /socket/ to the server on the port 8085
+        '/socket/**': {
             target: 'http://localhost:' + (process.env.SERVER_PROXY_PORT || "8085"),
             ws: true
            }


### PR DESCRIPTION
In the dev server proxy, it proxies requests from `/api/*` to the server.
This PR fixes it so that it only proxies requests starting with `/api/` instead of all starting with `/api`.
See https://github.com/webpack/webpack-dev-server/issues/2454 for details