### PR TITLE
Set working directory for debugging server

### DIFF
--- a/Content/.vscode/launch.json
+++ b/Content/.vscode/launch.json
@@ -12,6 +12,7 @@
                 "moduleLoad": false
             },
             "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/src/Server",
             "console": "internalConsole",
         },
         {


### PR DESCRIPTION
This sets the working directory in the vscode launch config for debugging the server.

Fixes #239