### PR TITLE
update Thoth.Fetch version

### DIFF
--- a/Content/paket.dependencies
+++ b/Content/paket.dependencies
@@ -46,7 +46,7 @@ group Client
     nuget FSharp.Control.AsyncRx ~> 1.0.0
 //#endif
 //#if (!remoting)
-    nuget Thoth.Fetch ~> 1
+    nuget Thoth.Fetch ~> 2
 //#endif
     nuget Fable.React ~> 5
 //#if (remoting)


### PR DESCRIPTION
Hi,

i had some issues with simple calls to a REST service because the template use the old Thoth.Fetch version 1.1.0 for the Client

https://github.com/MangelMaxime helped me to analyse my problem https://github.com/thoth-org/Thoth.Fetch/issues/16

and the solution was to bump up the version of his lib. It would be good to update the version in the template as well, so that other new devs will not have my problems :)

Regards