### PR TITLE
Remove legacy health checks entry from Google Cloud App Engine app.yaml

### DIFF
--- a/Content/app.yaml
+++ b/Content/app.yaml
@@ -1,12 +1,6 @@
 runtime: custom
 env: flex
 
-# Depends on the app
-# For more information, see:
-# https://cloud.google.com/appengine/docs/flexible/nodejs/reference/app-yaml#health_checks
-health_check:
-    enable_health_check: False
-
 # This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate
 # for production use. For more information, see:


### PR DESCRIPTION
Health check configuration has changed and initial deployment to Google App Engine fails currently. Related:
https://cloud.google.com/appengine/docs/flexible/dotnet/migrating-to-split-health-checks

Sample configuration file no longer has health_check section https://cloud.google.com/appengine/docs/flexible/dotnet/configuring-your-app-with-app-yaml