### PR TITLE
Fix devServerProxy context paths in V2 minimal

### DIFF
--- a/Content/src/Client/webpack.default.config.js
+++ b/Content/src/Client/webpack.default.config.js
@@ -23,13 +23,13 @@ var CONFIG = {
     // When using webpack-dev-server, you may need to redirect some calls
     // to a external API server. See https://webpack.js.org/configuration/dev-server/#devserver-proxy
     devServerProxy: {
-        // redirect requests that start with /api/* to the server on port 8085
-        '/api/*': {
+        // redirect requests that start with /api/ to the server on port 8085
+        '/api/**': {
             target: 'http://localhost:' + (process.env.SERVER_PROXY_PORT || "8085"),
                changeOrigin: true
            },
-        // redirect websocket requests that start with /socket/* to the server on the port 8085
-        '/socket/*': {
+        // redirect websocket requests that start with /socket/ to the server on the port 8085
+        '/socket/**': {
             target: 'http://localhost:' + (process.env.SERVER_PROXY_PORT || "8085"),
             ws: true
            }


### PR DESCRIPTION
Noticed that #341 didn't make it into one of the webpack configs in v2_minimal