### PR TITLE
Use Program.withReactSynchronous to avoid input focus bug

### DIFF
--- a/Content/src/Client/Client.fs
+++ b/Content/src/Client/Client.fs
@@ -155,7 +155,7 @@ Program.mkProgram init update view
 #if DEBUG
 |> Program.withConsoleTrace
 #endif
-|> Program.withReactBatched "elmish-app"
+|> Program.withReactSynchronous "elmish-app"
 #if DEBUG
 |> Program.withDebugger
 #endif


### PR DESCRIPTION
Whenever we add more than a handful of input fields to a SAFE project we see a bug where any input field change makes the cursor jump to the end of the field. Using `Program.withReactSynchronous` instead of `Program.withReactBatched` fixes this.