### PR TITLE
Simplify run test

### DIFF
--- a/Content/.gitignore
+++ b/Content/.gitignore
@@ -1,5 +1,6 @@
 .fable/
 .fake/
+.farmer/
 .idea/
 .ionide/
 .vs/

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -63,23 +63,16 @@ Target.create "Azure" (fun _ ->
     |> ignore
 )
 
-Target.create "Run" (fun _ ->
+let run clientCommand sharedPath serverPath _ =
     dotnet "build" sharedPath
-    [ async { dotnet "watch run" serverPath }
-      async { npm "run start" clientPath } ]
+    [ async { dotnet "watch run --no-restore" serverPath }
+      async { npm ("run " + clientCommand) clientPath } ]
     |> Async.Parallel
     |> Async.RunSynchronously
     |> ignore
-)
 
-Target.create "RunTests" (fun _ ->
-    dotnet "build" sharedTestsPath
-    [ async { dotnet "watch run" serverTestsPath }
-      async { npm "run test:live" clientPath } ]
-    |> Async.Parallel
-    |> Async.RunSynchronously
-    |> ignore
-)
+Target.create "Run" (run "start" sharedPath serverPath)
+Target.create "RunTests" (run "test:live" sharedTestsPath serverTestsPath )
 
 open Fake.Core.TargetOperators
 


### PR DESCRIPTION
This combined the Run and RunTests fake targets in a single parameterised function. It also uses `--no-restore` to speed up performance of .NET Watch.