### PR TITLE
Use `do` instead of `->` when yielding todos

### DIFF
--- a/Content/src/Client/Index.fs
+++ b/Content/src/Client/Index.fs
@@ -96,7 +96,7 @@ let containerBox (model : Model) (dispatch : Msg -> unit) =
     Box.box' [ ] [
         Content.content [ ] [
             Content.Ol.ol [ ] [
-                for todo in model.Todos ->
+                for todo in model.Todos do
                     li [ ] [ str todo.Description ]
             ]
         ]


### PR DESCRIPTION
I think we should avoid the arrow syntax as many people aren't aware that it exists and it doesn't play nicely with implicit yield. If you put another item adjacent to it you have to use the yield keyword.