### PR TITLE
Fixed link for Saturn documentation

### DIFF
--- a/Content/default/README.md
+++ b/Content/default/README.md
@@ -36,6 +36,6 @@ If you want to know more about the full Azure Stack and all of it's components (
 
 You will find more documentation about the used F# components at the following places:
 
-* [Saturn](https://saturnframework.org/docs/)
+* [Saturn](https://saturnframework.org/explanations/overview.html)
 * [Fable](https://fable.io/docs/)
 * [Elmish](https://elmish.github.io/elmish/)

--- a/Content/minimal/README.md
+++ b/Content/minimal/README.md
@@ -28,6 +28,6 @@ If you want to know more about the full Azure Stack and all of its components (i
 
 You will find more documentation about the used F# components at the following places:
 
-* [Saturn](https://saturnframework.org/docs/)
+* [Saturn](https://saturnframework.org/explanations/overview.html)
 * [Fable](https://fable.io/docs/)
 * [Elmish](https://elmish.github.io/elmish/)


### PR DESCRIPTION
https://saturnframework.org/docs returns a 404