### PR TITLE
Add dotnet fable clean

### DIFF
--- a/Content/default/Build.fs
+++ b/Content/default/Build.fs
@@ -15,7 +15,10 @@ let sharedTestsPath = Path.getFullName "tests/Shared"
 let serverTestsPath = Path.getFullName "tests/Server"
 let clientTestsPath = Path.getFullName "tests/Client"
 
-Target.create "Clean" (fun _ -> Shell.cleanDir deployPath)
+Target.create "Clean" (fun _ ->
+    Shell.cleanDir deployPath
+    run dotnet "fable clean --yes" "." // Delete *.fs.js files created by Fable
+)
 
 Target.create "InstallClient" (fun _ -> run npm "install" ".")
 

--- a/Content/default/SAFE.App.sln
+++ b/Content/default/SAFE.App.sln
@@ -5,7 +5,6 @@ VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{08CCFCF6-2248-43ED-A6EF-E972A2DA0E6A}"
 	ProjectSection(SolutionItems) = preProject
-		build.fsx = build.fsx
 		paket.dependencies = paket.dependencies
 		paket.lock = paket.lock
 		package-lock.json = package-lock.json


### PR DESCRIPTION
While working on SAFE apps I often find that Fable gets into a bad state with cached JS files which isn't fixed by restarting the build script, so I always add this command to delete all `*.fs.js` files.