### PR TITLE
Replace deprecated Expecto entrypoint

### DIFF
--- a/Content/default/tests/Server/Server.Tests.fs
+++ b/Content/default/tests/Server/Server.Tests.fs
@@ -25,4 +25,4 @@ let all =
         ]
 
 [<EntryPoint>]
-let main _ = runTests defaultConfig all
+let main _ = runTestsWithCLIArgs [] [||] all


### PR DESCRIPTION
This PR replaces the server test's entry point with the recommended function. 

## Why

Expecto's `runTests` is deprecated.

https://github.com/haf/expecto#runtests.