### PR TITLE
Added meta tag for viewport to help with mobile responsiveness

### DIFF
--- a/Content/default/src/Client/index.html
+++ b/Content/default/src/Client/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>SAFE Template</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="/favicon.png"/>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.0/css/bulma.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css">

--- a/Content/minimal/src/Client/index.html
+++ b/Content/minimal/src/Client/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>SAFE Template</title>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="/favicon.png"/>
 </head>
 <body>


### PR DESCRIPTION
Included the following meta tag in index.html for both templates

```
<meta name="viewport" content="width=device-width, initial-scale=1.0">
```
Before

<img src="https://user-images.githubusercontent.com/47211632/126210284-adfd5afb-efe0-420b-b373-404e75fe6272.PNG" width="200" height="400" />

After
<img src="https://user-images.githubusercontent.com/47211632/126210293-fd0c5c0b-691b-443c-a506-6c6d5010f1b8.PNG" width="200" height="400" />


