### PR TITLE
Reformat default server.fs - use DI

### DIFF
--- a/Content/default/src/Server/Server.fs
+++ b/Content/default/src/Server/Server.fs
@@ -2,52 +2,50 @@ module Server
 
 open Fable.Remoting.Server
 open Fable.Remoting.Giraffe
+open Microsoft.AspNetCore.Http
+open Microsoft.Extensions.DependencyInjection
 open Saturn
-
 open Shared
 
-type Storage() =
-    let todos = ResizeArray<_>()
+type Storage () as this =
+    let todos = ResizeArray()
+    do
+        this.AddTodo (Todo.create "Create new SAFE project") |> ignore
+        this.AddTodo (Todo.create "Write your app") |> ignore
+        this.AddTodo (Todo.create "Ship it !!!") |> ignore
 
-    member __.GetTodos() = List.ofSeq todos
-
-    member __.AddTodo(todo: Todo) =
+    member _.GetTodos () =
+        List.ofSeq todos
+    member _.AddTodo (todo: Todo) =
         if Todo.isValid todo.Description then
             todos.Add todo
             Ok()
         else
             Error "Invalid todo"
 
-let storage = Storage()
-
-storage.AddTodo(Todo.create "Create new SAFE project")
-|> ignore
-
-storage.AddTodo(Todo.create "Write your app")
-|> ignore
-
-storage.AddTodo(Todo.create "Ship it !!!")
-|> ignore
-
-let todosApi =
-    { getTodos = fun () -> async { return storage.GetTodos() }
-      addTodo =
-          fun todo ->
-              async {
-                  match storage.AddTodo todo with
-                  | Ok () -> return todo
-                  | Error e -> return failwith e
-              } }
+let todosApi (context:HttpContext) =
+    let storage = context.GetService<Storage>()
+    {
+        getTodos = fun () -> async {
+            return storage.GetTodos()
+        }
+        addTodo = fun todo -> async {
+            match storage.AddTodo todo with
+            | Ok () -> return todo
+            | Error e -> return failwith e
+        }
+    }
 
 let webApp =
     Remoting.createApi ()
     |> Remoting.withRouteBuilder Route.builder
-    |> Remoting.fromValue todosApi
+    |> Remoting.fromContext todosApi
     |> Remoting.buildHttpHandler
 
 let app =
     application {
         url "http://0.0.0.0:8085"
+        service_config (fun services -> services.AddSingleton<Storage>())
         use_router webApp
         memory_cache
         use_static "public"


### PR DESCRIPTION
Keeps the class-based structure, but makes the following changes:

* Move the initialisation of the in-memory DB into the Storage class.
* Registration of the service as a singleton into ASP .NET service collection.
* Retrieval of the service through the Http Context's `GetService` method.
* Small formatting changes.