### PR TITLE
Update Farmer to 1.6.12

### DIFF
--- a/Content/default/paket.lock
+++ b/Content/default/paket.lock
@@ -133,7 +133,7 @@ NUGET
     Fake.IO.FileSystem (5.20.4)
       Fake.Core.String (>= 5.20.4)
       FSharp.Core (>= 4.7.2)
-    Farmer (1.6.1)
+    Farmer (1.6.12)
       FSharp.Core (>= 5.0)
     Feliz (1.47)
       Fable.Core (>= 3.1.5)


### PR DESCRIPTION
Fixes #464, Fixes #461. This enables error checking on running the FAKE Deploy step if the name of the app leads to the template creating an invalid web app name, which will be rejected by Azure.