### PR TITLE
Update Server tests to use module that replaced class

### DIFF
--- a/Content/default/tests/Server/Server.Tests.fs
+++ b/Content/default/tests/Server/Server.Tests.fs
@@ -7,14 +7,13 @@ open Server
 
 let server = testList "Server" [
     testCase "Adding valid Todo" <| fun _ ->
-        let storage = Storage()
         let validTodo = Todo.create "TODO"
         let expectedResult = Ok ()
 
-        let result = storage.AddTodo validTodo
+        let result = Storage.addTodo validTodo
 
         Expect.equal result expectedResult "Result should be ok"
-        Expect.contains (storage.GetTodos()) validTodo "Storage should contain new todo"
+        Expect.contains Storage.todos validTodo "Storage should contain new todo"
 ]
 
 let all =


### PR DESCRIPTION
Currently the master branch has broken tests as they still use the old class that has been removed in #465. This PR fixes that.