### PR TITLE
Add .paket/ to .gitignore

### DIFF
--- a/Content/default/.gitignore
+++ b/Content/default/.gitignore
@@ -11,6 +11,7 @@ obj/
 bin/
 output/
 packages/
+.paket/
 paket-files/
 node_modules/
 release.cmd


### PR DESCRIPTION
As recommended at https://fsprojects.github.io/Paket/get-started.html.

> Make sure to add the following entries to your `.gitignore`:
>  ```gitignore
>  #Paket dependency manager
>  .paket/
>  paket-files/
>  ```