### PR TITLE
Update package.json files to allow node 18 (as well as 16)

### DIFF
--- a/Content/default/package-lock.json
+++ b/Content/default/package-lock.json
@@ -24,7 +24,7 @@
                 "webpack-dev-server": "^4.5.0"
             },
             "engines": {
-                "node": "~16",
+                "node": "~16 || ~18",
                 "npm": "~8"
             }
         },

--- a/Content/default/package.json
+++ b/Content/default/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "engines": {
-        "node": "~16",
+        "node": "~16 || ~18",
         "npm": "~8"
     },
     "scripts": {

--- a/Content/minimal/package-lock.json
+++ b/Content/minimal/package-lock.json
@@ -12,7 +12,7 @@
                 "webpack-dev-server": "^4.5.0"
             },
             "engines": {
-                "node": "~16",
+                "node": "~16 || ~18",
                 "npm": "~8"
             }
         },

--- a/Content/minimal/package.json
+++ b/Content/minimal/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "engines": {
-        "node": "~16",
+        "node": "~16 || ~18",
         "npm": "~8"
     },
     "scripts": {


### PR DESCRIPTION
The templates work with node v18 (current latest LTS), so we could allow it.