### PR TITLE
Fix failing build because of NPM version

### DIFF
--- a/Content/default/package-lock.json
+++ b/Content/default/package-lock.json
@@ -25,7 +25,7 @@
             },
             "engines": {
                 "node": "~16 || ~18",
-                "npm": "~8"
+                "npm": "~8 || ~9"
             }
         },
         "node_modules/@discoveryjs/json-ext": {

--- a/Content/default/package.json
+++ b/Content/default/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "engines": {
         "node": "~16 || ~18",
-        "npm": "~8"
+        "npm": "~8 || ~9"
     },
     "scripts": {
         "start": "webpack-dev-server --mode development",

--- a/Content/minimal/package-lock.json
+++ b/Content/minimal/package-lock.json
@@ -13,7 +13,7 @@
             },
             "engines": {
                 "node": "~16 || ~18",
-                "npm": "~8"
+                "npm": "~8 || ~9"
             }
         },
         "node_modules/@discoveryjs/json-ext": {

--- a/Content/minimal/package.json
+++ b/Content/minimal/package.json
@@ -2,7 +2,7 @@
     "private": true,
     "engines": {
         "node": "~16 || ~18",
-        "npm": "~8"
+        "npm": "~8 || ~9"
     },
     "scripts": {
         "start": "webpack-dev-server --mode development"


### PR DESCRIPTION
Build currently fails with:
```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: undefined
npm ERR! notsup Not compatible with your version of node/npm: undefined
npm ERR! notsup Required: {"node":"~16 || ~18","npm":"~8"}
npm ERR! notsup Actual:   {"npm":"9.5.1","node":"v18.16.0"}
```

https://compositional-it.visualstudio.com/SAFE%20Template/_build/results?buildId=13090&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=9c939e41-62c2-5605-5e05-fc3554afc9f5