### PR TITLE
Remove unnecessary type annotations on main files.

### DIFF
--- a/Content/default/src/Client/Index.fs
+++ b/Content/default/src/Client/Index.fs
@@ -17,14 +17,12 @@ let todosApi =
     |> Remoting.withRouteBuilder Route.builder
     |> Remoting.buildProxy<ITodosApi>
 
-let init () : Model * Cmd<Msg> =
+let init () =
     let model = { Todos = []; Input = "" }
-
     let cmd = Cmd.OfAsync.perform todosApi.getTodos () GotTodos
-
     model, cmd
 
-let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
+let update msg model =
     match msg with
     | GotTodos todos -> { model with Todos = todos }, Cmd.none
     | SetInput value -> { model with Input = value }, Cmd.none
@@ -43,7 +41,7 @@ let update (msg: Msg) (model: Model) : Model * Cmd<Msg> =
 
 open Feliz
 
-let private todoAction (model: Model) (dispatch: Dispatch<Msg>) =
+let private todoAction model dispatch =
     Html.div [
         prop.classes [ "flex"; "flex-col"; "sm:flex-row"; "mt-4"; "gap-4" ]
         prop.children [
@@ -92,7 +90,7 @@ let private todoAction (model: Model) (dispatch: Dispatch<Msg>) =
         ]
     ]
 
-let private todoList (model: Model) (dispatch: Dispatch<Msg>) =
+let private todoList model dispatch =
     Html.div [
         prop.classes [
             "bg-white/80"
@@ -116,7 +114,7 @@ let private todoList (model: Model) (dispatch: Dispatch<Msg>) =
         ]
     ]
 
-let view (model: Model) (dispatch: Dispatch<Msg>) =
+let view model dispatch =
     Html.section [
         prop.classes [ "h-screen"; "w-screen" ]
         prop.style [

--- a/Content/default/src/Server/Server.fs
+++ b/Content/default/src/Server/Server.fs
@@ -9,7 +9,7 @@ open Shared
 module Storage =
     let todos = ResizeArray()
 
-    let addTodo (todo: Todo) =
+    let addTodo todo =
         if Todo.isValid todo.Description then
             todos.Add todo
             Ok()


### PR DESCRIPTION
Pretty self explanatory. Most IDEs do sufficiently well to provide annotations hints that they aren't required e.g. in VSCode with Ionide:

![image](https://github.com/SAFE-Stack/SAFE-template/assets/1781813/d1cc6fd7-26b7-4618-a158-e9840af148fd)
