### PR TITLE
Use Github actions to automate the release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: SAFE Template release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Tool restore
+        run: dotnet tool restore
+
+      - name: Package
+        env:
+          VERSION: ${{ github.ref_name }}
+          RELEASE_NOTES_URL: ${{ github.event.release.html_url }}
+          RELEASE_NOTES_BODY: ${{ github.event.release.body }}
+        run: dotnet run --project Build.fsproj -- Package
+
+      - name: Publish
+        run: dotnet nuget push "*.nupkg" --api-key ${{secrets.NUGET_API_KEY}} --source https://api.nuget.org/v3/index.json

--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -8,7 +8,7 @@
         "Fable",
         "Elmish"
     ],
-    "name": "SAFE-Stack Web App v5.0.4",
+    "name": "SAFE-Stack Web App",
     "tags": {
         "language": "F#",
         "type": "project"

--- a/SAFE.Template.proj
+++ b/SAFE.Template.proj
@@ -1,47 +1,51 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Description>SAFE Stack Template</Description>
-    <Authors>Tomasz Heimowski</Authors>
-    <PackageProjectUrl>https://github.com/SAFE-Stack/SAFE-template</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/SAFE-Stack/SAFE-template/blob/master/LICENSE</PackageLicenseUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/SAFE-Stack/SAFE-template/master/safe-logo.png</PackageIconUrl>
-    <RepositoryUrl>https://github.com/SAFE-Stack/SAFE-template.git</RepositoryUrl>
-    <PackageTags>template;fsharp;saturn;azure;fable;elmish</PackageTags>
-    <NeutralLanguage>en-US</NeutralLanguage>
-    <PackageType>Template</PackageType>
-    <NoBuild>true</NoBuild>
-    <IncludeBuildOutput>false</IncludeBuildOutput>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- https://github.com/dotnet/templating/issues/2350#issuecomment-610431461 -->
-    <NoDefaultExcludes>true</NoDefaultExcludes>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ExcludeFromPackage>
-Content/**/.fake/**/*;
-Content/**/.ionide/**/*;
-Content/**/.cache/**/*;
-Content/**/.fable/**/*;
-Content/**/node_modules/**/*;
-Content/**/obj/**/*;
-Content/**/bin/**/*;
-Content/**/.fable/**/*;
-Content/**/*.fs.js;
-Content/**/*.fs.js.map;
-Content/**/deploy/**/*;
-Content/**/tests/**/obj/**/*;
-Content/**/tests/**/bin/**/*;
-Content/**/packages/**/*;
-Content/**/paket-files/**/*;
-Content/**/src/Client/deploy/**/*;
-Content/**/Client/output/**/*;
-Content/**/Client/fable_modules/**/*;
+    <PropertyGroup>
+        <Description>SAFE Stack Template</Description>
+        <Authors>Tomasz Heimowski</Authors>
+        <PackageProjectUrl>https://github.com/SAFE-Stack/SAFE-template</PackageProjectUrl>
+        <PackageLicense>LICENSE</PackageLicense>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageIcon>safe-logo.png</PackageIcon>
+        <RepositoryUrl>https://github.com/SAFE-Stack/SAFE-template.git</RepositoryUrl>
+        <PackageTags>template;fsharp;saturn;azure;fable;elmish</PackageTags>
+        <NeutralLanguage>en-US</NeutralLanguage>
+        <PackageType>Template</PackageType>
+        <NoBuild>true</NoBuild>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <!-- https://github.com/dotnet/templating/issues/2350#issuecomment-610431461 -->
+        <NoDefaultExcludes>true</NoDefaultExcludes>
+    </PropertyGroup>
+    <PropertyGroup>
+        <ExcludeFromPackage>
+            Content/**/.fake/**/*;
+            Content/**/.ionide/**/*;
+            Content/**/.cache/**/*;
+            Content/**/.fable/**/*;
+            Content/**/node_modules/**/*;
+            Content/**/obj/**/*;
+            Content/**/bin/**/*;
+            Content/**/.fable/**/*;
+            Content/**/*.fs.js;
+            Content/**/*.fs.js.map;
+            Content/**/deploy/**/*;
+            Content/**/tests/**/obj/**/*;
+            Content/**/tests/**/bin/**/*;
+            Content/**/packages/**/*;
+            Content/**/paket-files/**/*;
+            Content/**/src/Client/deploy/**/*;
+            Content/**/Client/output/**/*;
+            Content/**/Client/fable_modules/**/*;
         </ExcludeFromPackage>
-  </PropertyGroup>
-  <ItemGroup>
-    <Content Include="Content/**/*.*" Exclude="$(ExcludeFromPackage)">
-      <PackagePath>Content\</PackagePath>
-    </Content>
-  </ItemGroup>
-  <Import Project=".paket\Paket.Restore.targets" />
+    </PropertyGroup>
+    <ItemGroup>
+        <Content Include="Content/**/*.*" Exclude="$(ExcludeFromPackage)">
+            <PackagePath>Content\</PackagePath>
+        </Content>
+        <None Include="safe-logo.png" Pack="true" PackagePath=""/>
+        <None Include="README.md" Pack="true" PackagePath=""/>
+        <None Include="LICENSE" Pack="true" PackagePath=""/>
+    </ItemGroup>
+    <Import Project=".paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
- Add a Github action that is triggered on Github release
- Automation of release notes process that is generated using the PR's merged since last release
- Version is driven from the version in the Github release
- Release notes in the Nuget package is now a link to the Github release notes
- Nuget push now is done on the build machine only
- Nuget secret is now a secret on the repository
- The template proj file using up to date constructs for licence, readme and logo