### PR TITLE
Fix HMR

### DIFF
--- a/Content/default/src/Client/vite.config.mts
+++ b/Content/default/src/Client/vite.config.mts
@@ -18,6 +18,9 @@ export default defineConfig({
                 target: proxyTarget,
                 changeOrigin: true,
             }
-        }
+        },
+        watch: {
+            ignored: [ "**/*.fs" ]
+        },
     }
 });

--- a/Content/minimal/src/Client/vite.config.mts
+++ b/Content/minimal/src/Client/vite.config.mts
@@ -16,6 +16,9 @@ export default defineConfig({
                 target: proxyTarget,
                 changeOrigin: true,
             }
-        }
+        },
+        watch: {
+            ignored: [ "**/*.fs" ]
+        },
     }
 });


### PR DESCRIPTION
## Why was HMR broken?

Example sequence of events:
1. Change made to e.g. `Index.fs`
2. Fable **and Vite** notice a change to the file...
    - Vite doesn't know how to hot reload a `.fs` file, so it does a full refresh, just in case.
    - Fable does a recompile
3. Vite sees the new `.js` files from Fable recompile and does a HMR

## Fix
Instruct Vite not to watch `.fs` files.