### PR TITLE
Do `dotnet tool restore` automatically in build target

### DIFF
--- a/Build.fsproj
+++ b/Build.fsproj
@@ -12,4 +12,7 @@
   </ItemGroup>
 
   <Import Project=".paket\Paket.Restore.targets" />
+  <Target Name="DotNetToolRestore" BeforeTargets="PaketRestore">
+    <Exec Command="dotnet tool restore" />
+  </Target>
 </Project>

--- a/Content/default/Build.fsproj
+++ b/Content/default/Build.fsproj
@@ -12,4 +12,7 @@
       <None Include="paket.references" />
   </ItemGroup>
   <Import Project=".paket\Paket.Restore.targets" />
+  <Target Name="DotNetToolRestore" BeforeTargets="PaketRestore">
+    <Exec Command="dotnet tool restore" />
+  </Target>
 </Project>

--- a/Content/default/README.md
+++ b/Content/default/README.md
@@ -12,12 +12,6 @@ You'll need to install the following pre-requisites in order to build SAFE appli
 
 ## Starting the application
 
-Before you run the project **for the first time only** you must install dotnet "local tools" with this command:
-
-```bash
-dotnet tool restore
-```
-
 To concurrently run the server and the client components in watch mode use the following command:
 
 ```bash


### PR DESCRIPTION
By adding a target in Build.fsproj to run `dotnet tool restore`, we can remove the step that requires users to do it manually.

Should we go ahead with this? Discussion welcome.