### PR TITLE
Fix bug issue #615 in Client.Tests.fs

### DIFF
--- a/Content/default/tests/Client/Client.Tests.fs
+++ b/Content/default/tests/Client/Client.Tests.fs
@@ -12,7 +12,7 @@ let client =
         <| fun _ ->
             let newTodo = Todo.create "new todo"
             let model, _ = init ()
-
+            let model, _ = update (LoadTodos (Finished [])) model
             let model, _ = update (SaveTodo(Finished newTodo)) model
 
             Expect.equal


### PR DESCRIPTION
Fix bug issue #615

Helping Copilot to explain the fix, **ex-post**.

> giuliohome: explain why adding line "let model, _ = update (LoadTodos (Finished [])) model" fix a bug so that the test does not fail now

>GitHub Copilot: The line `let model, _ = update (LoadTodos (Finished [])) model` is loading an empty list of todos into the model. This is likely fixing a bug where the model's todo list was not initialized properly, causing the test to fail.

> In the previous state, the model might have been in an uninitialized state or contained some stale data. By explicitly loading an empty list of todos, it ensures that the model is in a known and clean state before the test starts to add a new todo. This makes the test more reliable and predictable, as it's not affected by the previous state of the model. 

> This is a common practice in unit testing, where each test should be isolated and not depend on the state from other tests. It's also part of the Arrange-Act-Assert pattern, where you first arrange (set up) the system under test, then act on it, and finally assert that it behaved as expected. In this case, loading the empty list of todos is part of the arrange phase.


**Now in my words.** 

The issue arises because the `init` function generates a model with todos that have not started yet. As a result, the remote `map` used for the `Length` assertion doesn't map to any function, causing the test to fail.