### PR TITLE
Use npm ci in the build script so package.lock cannot get updated there

### DIFF
--- a/Content/default/Build.fs
+++ b/Content/default/Build.fs
@@ -20,7 +20,7 @@ Target.create "Clean" (fun _ ->
     run dotnet [ "fable"; "clean"; "--yes" ] clientPath // Delete *.fs.js files created by Fable
 )
 
-Target.create "InstallClient" (fun _ -> run npm [ "install" ] ".")
+Target.create "InstallClient" (fun _ -> run npm [ "ci" ] ".")
 
 Target.create "Bundle" (fun _ ->
     [

--- a/Content/default/Build.fs
+++ b/Content/default/Build.fs
@@ -20,7 +20,7 @@ Target.create "Clean" (fun _ ->
     run dotnet [ "fable"; "clean"; "--yes" ] clientPath // Delete *.fs.js files created by Fable
 )
 
-Target.create "InstallClient" (fun _ -> run npm [ "ci" ] ".")
+Target.create "RestoreClientDependencies" (fun _ -> run npm [ "ci" ] ".")
 
 Target.create "Bundle" (fun _ ->
     [
@@ -67,11 +67,11 @@ Target.create "Format" (fun _ -> run dotnet [ "fantomas"; "." ] ".")
 open Fake.Core.TargetOperators
 
 let dependencies = [
-    "Clean" ==> "InstallClient" ==> "Bundle" ==> "Azure"
+    "Clean" ==> "RestoreClientDependencies" ==> "Bundle" ==> "Azure"
 
-    "Clean" ==> "InstallClient" ==> "Run"
+    "Clean" ==> "RestoreClientDependencies" ==> "Run"
 
-    "InstallClient" ==> "RunTests"
+    "RestoreClientDependencies" ==> "RunTests"
 ]
 
 [<EntryPoint>]


### PR DESCRIPTION
addresses #618

* NPM ci only installs packages according to package.json and package.lock, failing if they don't line up. CI is faster and will prevent unexpected changes to package.lock until the developer explicitly uses NPM install