### PR TITLE
Change the api to return full TODO list after adding todo

### DIFF
--- a/Content/default/src/Client/Index.fs
+++ b/Content/default/src/Client/Index.fs
@@ -12,7 +12,7 @@ type Model = {
 type Msg =
     | SetInput of string
     | LoadTodos of ApiCall<unit, Todo list>
-    | SaveTodo of ApiCall<string, Todo>
+    | SaveTodo of ApiCall<string, Todo list>
 
 let todosApi = Api.makeProxy<ITodosApi> ()
 
@@ -40,10 +40,10 @@ let update msg model =
                 Cmd.OfAsync.perform todosApi.addTodo todo (Finished >> SaveTodo)
 
             { model with Input = "" }, saveTodoCmd
-        | Finished todo ->
+        | Finished todos ->
             {
                 model with
-                    Todos = model.Todos |> RemoteData.map (fun todos -> todos @ [ todo ])
+                    Todos = RemoteData.Loaded todos
             },
             Cmd.none
 

--- a/Content/default/src/Server/Server.fs
+++ b/Content/default/src/Server/Server.fs
@@ -25,7 +25,7 @@ let todosApi ctx = {
         fun todo -> async {
             return
                 match Storage.addTodo todo with
-                | Ok() -> todo
+                | Ok() -> Storage.todos |> List.ofSeq
                 | Error e -> failwith e
         }
 }

--- a/Content/default/src/Shared/Shared.fs
+++ b/Content/default/src/Shared/Shared.fs
@@ -15,5 +15,5 @@ module Todo =
 
 type ITodosApi = {
     getTodos: unit -> Async<Todo list>
-    addTodo: Todo -> Async<Todo>
+    addTodo: Todo -> Async<Todo list>
 }

--- a/Content/default/tests/Client/Client.Tests.fs
+++ b/Content/default/tests/Client/Client.Tests.fs
@@ -12,8 +12,7 @@ let client =
         <| fun _ ->
             let newTodo = Todo.create "new todo"
             let model, _ = init ()
-            let model, _ = update (LoadTodos (Finished [])) model
-            let model, _ = update (SaveTodo(Finished newTodo)) model
+            let model, _ = update (SaveTodo(Finished [ newTodo ])) model
 
             Expect.equal
                 (model.Todos |> RemoteData.map _.Length |> RemoteData.defaultValue 0)
@@ -30,11 +29,11 @@ let client =
 
 let all =
     testList "All" [
-//-:cnd:noEmit
+        //-:cnd:noEmit
 #if FABLE_COMPILER // This preprocessor directive makes editor happy
         Shared.Tests.shared
 #endif
-//+:cnd:noEmit
+        //+:cnd:noEmit
         client
     ]
 


### PR DESCRIPTION
Addresses #615 in a more conclusive manner:

* Test failed because it lacked loading the initial data; because the added todo was mapped into a RemoteData type, data disappeared quietly when that RemoteData object was not in the Finished state yet.
* Solution: Make the API return the full todo list, so you can fully replace the todo list after an update
 