### PR TITLE
Fix error caused by restore on running tests + build solution before run, instead of just restore

### DIFF
--- a/Content/default/Build.fs
+++ b/Content/default/Build.fs
@@ -74,16 +74,11 @@ Target.create "Format" (fun _ -> run dotnet [ "fantomas"; "." ] ".")
 open Fake.Core.TargetOperators
 
 let dependencies = [
-    "Build" ==> "RunTestsHeadless"
-    "Build" ==> "WatchRunTests"
-    "Build" ==> "Run"
-
     "Clean" ==> "RestoreClientDependencies" ==> "Bundle" ==> "Azure"
+    "Clean" ==> "RestoreClientDependencies" ==> "Build" ==> "Run"
 
-    "Clean" ==> "RestoreClientDependencies" ==> "Run"
-
-    "RestoreClientDependencies" ==> "RunTestsHeadless"
-    "RestoreClientDependencies" ==> "WatchRunTests"
+    "RestoreClientDependencies" ==> "Build" ==> "RunTestsHeadless"
+    "RestoreClientDependencies" ==> "Build" ==> "WatchRunTests"
 ]
 
 [<EntryPoint>]


### PR DESCRIPTION
* Remove dotnet restore action before running the watcher
* instead of building just the shared path, build the full solution
* Use `no-restore` when running server tests
* restore full solution before running any tests


addresses what is left of #626 after partial fix in #634 