### PR TITLE
Default configuration for Tailwind updated to NOT scan node_modules for content.

### DIFF
--- a/Content/default/src/Client/tailwind.config.js
+++ b/Content/default/src/Client/tailwind.config.js
@@ -4,6 +4,7 @@ module.exports = {
     content: [
         "./index.html",
         "./**/*.{fs,js,ts,jsx,tsx}",
+        "!./node_modules/**/*",
     ],
     theme: {
         extend: {},


### PR DESCRIPTION
This pull request removes the directory node_modules from tailwind content scan. 

As a bonus it also removes the 3 error lines when running the template that the tailwind. configuration should be altered to remove node_modules. 

